### PR TITLE
require `mule-util`

### DIFF
--- a/calfw-blocks.el
+++ b/calfw-blocks.el
@@ -31,6 +31,7 @@
 ;;; Code:
 
 (require 'calfw)
+(require 'mule-util)
 
 (defcustom calfw-blocks-initial-visible-time '(8 0)
   "Earliest initial visible time as list (hours minutes)."


### PR DESCRIPTION
needed for `calfw-blocks--to-lines`

(otherwise, when running unconfigured emacs, get `calfw-blocks--to-lines: Symbol’s function definition is void: truncate-string-ellipsis`)