### PR TITLE
Preserve org event properties in transpose view

### DIFF
--- a/calfw-transpose.el
+++ b/calfw-transpose.el
@@ -217,10 +217,23 @@ return an alist of rendering parameters."
                              (string= (substring content 0 5) begintime))
                         (concat begintime "-" endtime (substring content 5))
                       content))
+            for event = (get-text-property 0 'cfw:event content)
             collect
             (if content
-                (calfw--render-default-content-face title)
+                (calfw-transpose-copy-event-properties title event)
               "")))))
+
+(defun calfw-transpose-copy-event-properties (title event)
+  "[internal] Apply face to TITLE and copy event properties from EVENT.
+Returns TITLE with face applied and all org-related properties preserved."
+  (let ((faced-title (calfw--render-default-content-face title)))
+    (when event
+      (let ((event-title (calfw-event-title event)))
+        (dolist (prop '(org-marker org-link cfw:org-file cfw:org-h-beg cfw:org-loc keymap))
+          (when-let ((val (get-text-property 0 prop event-title)))
+            (put-text-property 0 (length faced-title) prop val faced-title)))
+        (put-text-property 0 (length faced-title) 'cfw:event event faced-title)))
+    faced-title))
 
 (defun calfw-transpose-render-columns (day-columns param)
   "Concatenates each row on the days into a string of a physical line.

--- a/calfw-transpose.el
+++ b/calfw-transpose.el
@@ -126,10 +126,7 @@ return an alist of rendering parameters."
      (calfw--rt
       (calfw-render-title-period begin-date end-date)
       'calfw-title-face)
-     EOL (calfw-blocks-render-toolbar total-width 'week
-                             (calfw-blocks-navi-previous-nday-week-command n)
-                             (calfw-blocks-navi-next-nday-week-command n))
-     EOL)
+     EOL (calfw--render-toolbar total-width (calfw-component-view component)) EOL)
     (insert cline)
     ;; contents
     (calfw-transpose-render-calendar-cells-weeks

--- a/calfw-transpose.el
+++ b/calfw-transpose.el
@@ -214,23 +214,11 @@ return an alist of rendering parameters."
                              (string= (substring content 0 5) begintime))
                         (concat begintime "-" endtime (substring content 5))
                       content))
-            for event = (get-text-property 0 'cfw:event content)
+            for formatted-content = (apply #'propertize title (text-properties-at 0 content))
             collect
             (if content
-                (calfw-transpose-copy-event-properties title event)
+                (calfw--render-default-content-face formatted-content)
               "")))))
-
-(defun calfw-transpose-copy-event-properties (title event)
-  "[internal] Apply face to TITLE and copy event properties from EVENT.
-Returns TITLE with face applied and all org-related properties preserved."
-  (let ((faced-title (calfw--render-default-content-face title)))
-    (when event
-      (let ((event-title (calfw-event-title event)))
-        (dolist (prop '(org-marker org-link cfw:org-file cfw:org-h-beg cfw:org-loc keymap))
-          (when-let ((val (get-text-property 0 prop event-title)))
-            (put-text-property 0 (length faced-title) prop val faced-title)))
-        (put-text-property 0 (length faced-title) 'cfw:event event faced-title)))
-    faced-title))
 
 (defun calfw-transpose-render-columns (day-columns param)
   "Concatenates each row on the days into a string of a physical line.


### PR DESCRIPTION
In transpose view, rendered event titles lost org-related text properties,
which caused calfw-org-onclick to do nothing.

This patch preserves event properties (org-marker, cfw:event, keymap, etc.)
when reconstructing titles, making items clickable again and keeping faces
and behavior consistent with block view.